### PR TITLE
Fix incorrect index returned.

### DIFF
--- a/RapidFuzz.Net/RapidFuzz.Net/FuzzyMatcher.cs
+++ b/RapidFuzz.Net/RapidFuzz.Net/FuzzyMatcher.cs
@@ -35,6 +35,8 @@ public static class FuzzyMatcher
             {
                 yield return (score, index, value);
             }
+
+            index += 1;
         }
     }
 


### PR DESCRIPTION
Index is always set to 0 for all items in the enumeration. This change returns the index of the item instead.